### PR TITLE
Add MIT license headers and LICENSE file

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,56 @@
+# Dependencies and package managers
+node_modules/
+vendor/
+venv/
+.env/
+data/python-packages/
+service/src/app/
+
+# Build outputs
+dist/
+build/
+out/
+target/
+*.min.js
+*.min.css
+
+# Third party code
+third_party/
+external/
+libs/
+
+# Generated files
+*_generated.*
+*.gen.*
+*_pb2.py
+*.pb.go
+
+# Documentation
+*.md
+LICENSE
+NOTICE
+
+# Config files
+.gitignore
+.licenseignore
+package-lock.json
+yarn.lock
+go.sum
+
+# Binary and media files
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.pdf
+*.zip
+*.tar.gz
+
+# Service-specific exclusions (for epam-service-connector)
+service/LICENSE
+service/service.tar.gz
+
+# Third party JavaScript libraries
+public/js/highlight.pack.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Eclipse Foundation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/covesa/instance.ts
+++ b/covesa/instance.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 const instance = {
   name: "ETAS",
   policy_url: "https://www.etas.com/en/company/terms_of_use.php",

--- a/covesa/src/configs/config.ts
+++ b/covesa/src/configs/config.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { Config } from "@/types/addon.type";
 
 const config: Config = {

--- a/etas/instance.ts
+++ b/etas/instance.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 const instance = {
   name: "ETAS",
   policy_url: "https://www.etas.com/en/company/terms_of_use.php",

--- a/etas/src/configs/config.ts
+++ b/etas/src/configs/config.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { Config } from "@/types/addon.type";
 
 const config: Config = {


### PR DESCRIPTION
Related to eclipse-autowrx/dreamKIT#18

Add MIT license headers and LICENSE file for project compliance across AutoWRX ecosystem.